### PR TITLE
Added support for mailto: links

### DIFF
--- a/Classes/MDAboutController.h
+++ b/Classes/MDAboutController.h
@@ -30,10 +30,11 @@
 //  automatically by the code that links back to this page :)
 //
 
+#import <MessageUI/MFMailComposeViewController.h>
 #import <UIKit/UIKit.h>
 @class MDACCredit;
 
-@interface MDAboutController : UIViewController <UITableViewDataSource, UITableViewDelegate> {
+@interface MDAboutController : UIViewController <MFMailComposeViewControllerDelegate, UITableViewDataSource, UITableViewDelegate> {
     UIView *titleBar;
     UITableView *tableView;
     

--- a/Classes/MDAboutController.m
+++ b/Classes/MDAboutController.m
@@ -545,6 +545,20 @@ static NSString *MDACImageCellID        = @"MDACImageCell";
         cell.backgroundColor = [UIColor clearColor];
 }
 
+- (void)openMailToURL:(NSURL *)url subject:(NSString *)subject {
+    MFMailComposeViewController *mailer = [[[MFMailComposeViewController alloc] init] autorelease];
+    mailer.mailComposeDelegate = self;
+    [mailer setToRecipients:[NSArray arrayWithObject:url.resourceSpecifier]];
+    [mailer setSubject:subject];
+    [self presentModalViewController:mailer animated:YES];
+}
+
+- (void)mailComposeController:(MFMailComposeViewController*)controller  
+          didFinishWithResult:(MFMailComposeResult)result 
+                        error:(NSError*)error {
+    [self dismissModalViewControllerAnimated:YES];
+}
+
 - (void)tableView:(UITableView *)aTableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
@@ -564,7 +578,12 @@ static NSString *MDACImageCellID        = @"MDACImageCell";
         if ([(MDACListCredit *)credit itemAtIndex:index].link) {
             if ([(MDACListCredit *)credit itemAtIndex:index].link) {
                 if (!self.navigationController) {
-                    [[UIApplication sharedApplication] openURL:[(MDACListCredit *)credit itemAtIndex:index].link];
+                    NSURL *url = [(MDACListCredit *)credit itemAtIndex:index].link;
+                    if ([url.scheme isEqualToString:@"mailto"]) {
+                        [self openMailToURL:url subject:[(MDACListCredit *)credit itemAtIndex:index].name];
+                    } else {
+                        [[UIApplication sharedApplication] openURL:url];
+                    }
                 } else {
                     NSURL *url = [(MDACListCredit *)credit itemAtIndex:index].link;
                     


### PR DESCRIPTION
I've added special handling for mailto: links. When these are tapped, the iOS built-in mail compose window will slide up, pre-populated with the recipients mentioned in the link and using the name of the link as the subject.

Also, I've increased the maximum size of a text credit from 600pt to 1000pt.

Regards,
Denis
